### PR TITLE
Make display coordinates server-computed

### DIFF
--- a/src/db/admin-regions.ts
+++ b/src/db/admin-regions.ts
@@ -70,6 +70,23 @@ export async function findRegionByPoint(
   return data[0];
 }
 
+export async function getRandomPointInRegion(
+  countryCode: string,
+  level: number,
+  name: string,
+): Promise<{ lat: number; lng: number } | null> {
+  const client = getSupabaseClient();
+  const { data, error } = await client.rpc('random_point_in_region', {
+    p_country_code: countryCode,
+    p_level: level,
+    p_name: name,
+  });
+
+  if (error) throw new Error(`Random point lookup failed: ${error.message}`);
+  if (!data || data.length === 0) return null;
+  return { lat: data[0].lat, lng: data[0].lng };
+}
+
 export async function searchRegions(
   countryCode: string,
   query: string,

--- a/src/db/listings.ts
+++ b/src/db/listings.ts
@@ -1,7 +1,7 @@
 import { getSupabaseClient } from './client.js';
-import type { ListingInput, PriceHistoryEntry } from '../types/listing.js';
+import type { ListingInput, ListingInsertRow, PriceHistoryEntry } from '../types/listing.js';
 
-export async function insertListing(input: ListingInput): Promise<{ id: string }> {
+export async function insertListing(input: ListingInsertRow): Promise<{ id: string }> {
   const client = getSupabaseClient();
   const { error } = await client.from('listings').insert({
     listing_id: input.listing_id,
@@ -50,7 +50,7 @@ export async function insertListing(input: ListingInput): Promise<{ id: string }
   return { id: input.listing_id };
 }
 
-export async function insertListingsBatch(inputs: ListingInput[]): Promise<{ inserted: number; duplicates: string[] }> {
+export async function insertListingsBatch(inputs: ListingInsertRow[]): Promise<{ inserted: number; duplicates: string[] }> {
   const client = getSupabaseClient();
   const duplicates: string[] = [];
   let inserted = 0;

--- a/src/enrichment/location-enricher.ts
+++ b/src/enrichment/location-enricher.ts
@@ -1,34 +1,84 @@
 import type { ListingInput, LocationGranularity } from '../types/listing.js';
+import type { ListingInsertRow } from '../types/listing.js';
 import type { GeocodingResult } from './geocoding.js';
 import { getGeocodingProvider } from './geocoding.js';
 import { reverseGeocodePostGIS } from './postgis-geocoder.js';
+import { getRandomPointInRegion } from '../db/admin-regions.js';
 
 /**
  * Enriches location data on a listing based on what's already provided.
- * Never fabricates data more granular than the source.
+ * Computes display coordinates server-side (scrapers cannot set them).
  * Non-blocking: if geocoding fails, returns the listing unchanged.
  */
-export async function enrichLocation(input: ListingInput): Promise<ListingInput> {
-  const provider = getGeocodingProvider();
-  if (!provider) return input;
+export async function enrichLocation(input: ListingInput): Promise<ListingInsertRow> {
+  // Strip any display coordinates from scraper input — these are server-computed
+  const { display_latitude, display_longitude, ...cleaned } = input as ListingInput & {
+    display_latitude?: unknown;
+    display_longitude?: unknown;
+  };
 
+  const provider = getGeocodingProvider();
+  let enriched: ListingInput = cleaned;
+
+  if (provider) {
+    const granularity = cleaned.location_granularity;
+    try {
+      switch (granularity) {
+        case 'coordinates':
+          enriched = await enrichFromCoordinates(cleaned, provider);
+          break;
+        case 'address':
+          enriched = await enrichFromAddress(cleaned, provider);
+          break;
+        default:
+          break;
+      }
+    } catch (err) {
+      console.error('Location enrichment failed, proceeding without enrichment:', err);
+    }
+  }
+
+  return computeDisplayCoordinates(enriched);
+}
+
+async function computeDisplayCoordinates(input: ListingInput): Promise<ListingInsertRow> {
   const granularity = input.location_granularity;
 
-  try {
-    switch (granularity) {
-      case 'coordinates':
-        return await enrichFromCoordinates(input, provider);
-      case 'address':
-        return await enrichFromAddress(input, provider);
-      default:
-        // For postal_code, admin_level_*, and country — skip enrichment for now.
-        // These would require boundary polygon data to enrich properly.
-        return input;
+  // Exact coordinate modes: display = exact coords
+  if (granularity === 'coordinates' || granularity === 'address') {
+    if (input.latitude != null && input.longitude != null) {
+      return { ...input, display_latitude: input.latitude, display_longitude: input.longitude };
     }
-  } catch (err) {
-    console.error('Location enrichment failed, proceeding without enrichment:', err);
-    return input;
   }
+
+  // Admin level modes: display = random point in most granular polygon
+  const adminLevels: Array<{ level: number; name: string | null | undefined }> = [
+    { level: 4, name: input.admin_level_4 },
+    { level: 3, name: input.admin_level_3 },
+    { level: 2, name: input.admin_level_2 },
+    { level: 1, name: input.admin_level_1 },
+  ];
+
+  for (const { level, name } of adminLevels) {
+    if (name) {
+      try {
+        const point = await getRandomPointInRegion(input.country_code, level, name);
+        if (point) {
+          return { ...input, display_latitude: point.lat, display_longitude: point.lng };
+        }
+      } catch {
+        // Continue to next level if this one fails
+      }
+    }
+  }
+
+  // Fallback: if we have any coords at all, use them
+  if (input.latitude != null && input.longitude != null) {
+    return { ...input, display_latitude: input.latitude, display_longitude: input.longitude };
+  }
+
+  // Cannot compute — return without display coords (DB NOT NULL will reject)
+  return input as ListingInsertRow;
 }
 
 async function enrichFromCoordinates(

--- a/src/types/listing.ts
+++ b/src/types/listing.ts
@@ -32,8 +32,6 @@ export const ListingInputSchema = z.object({
   address_line_2: z.string().max(500).nullable().optional(),
   latitude: z.number().nullable().optional(),
   longitude: z.number().nullable().optional(),
-  display_latitude: z.number(),
-  display_longitude: z.number(),
   location_granularity: z.enum(LOCATION_GRANULARITIES),
   price_amount: z.number().int().nullable().optional(),
   price_currency_code: z.string().length(3).nullable().optional(),
@@ -54,7 +52,12 @@ export const ListingInputSchema = z.object({
 
 export type ListingInput = z.infer<typeof ListingInputSchema>;
 
-export interface ListingRow extends ListingInput {
+export interface ListingInsertRow extends ListingInput {
+  display_latitude: number;
+  display_longitude: number;
+}
+
+export interface ListingRow extends ListingInsertRow {
   listing_status: ListingStatus;
   price_history: PriceHistoryEntry[];
   created_at: string;

--- a/src/validation/rules/coordinates-in-country.ts
+++ b/src/validation/rules/coordinates-in-country.ts
@@ -42,15 +42,3 @@ export const coordinatesInCountry: ValidationRule = {
     return checkCoords(input.latitude, input.longitude, countryCode, 'latitude', 'longitude');
   },
 };
-
-export const displayCoordinatesInCountry: ValidationRule = {
-  name: 'display_coordinates_in_country',
-  check(input) {
-    const countryCode = input.country_code as string;
-    if (!countryCode) return [];
-    return checkCoords(
-      input.display_latitude, input.display_longitude,
-      countryCode, 'display_latitude', 'display_longitude',
-    );
-  },
-};

--- a/src/validation/rules/required-fields.ts
+++ b/src/validation/rules/required-fields.ts
@@ -7,8 +7,6 @@ const REQUIRED_FIELDS = [
   'listing_type',
   'country_code',
   'property_type',
-  'display_latitude',
-  'display_longitude',
   'location_granularity',
   'raw_data',
 ];

--- a/src/validation/rules/valid-types.ts
+++ b/src/validation/rules/valid-types.ts
@@ -17,8 +17,6 @@ const FIELD_TYPES: Record<string, 'string' | 'number' | 'integer' | 'object' | '
   address_line_2: 'string',
   latitude: 'number',
   longitude: 'number',
-  display_latitude: 'number',
-  display_longitude: 'number',
   location_granularity: 'string',
   price_amount: 'integer',
   price_currency_code: 'string',

--- a/src/validation/tier2-semantic.ts
+++ b/src/validation/tier2-semantic.ts
@@ -4,7 +4,7 @@ import { pricePlausible } from './rules/price-plausible.js';
 import { currencyMatchesConfig } from './rules/currency-matches-config.js';
 import { roomRanges } from './rules/room-ranges.js';
 import { areaRange } from './rules/area-range.js';
-import { coordinatesInCountry, displayCoordinatesInCountry } from './rules/coordinates-in-country.js';
+import { coordinatesInCountry } from './rules/coordinates-in-country.js';
 import { priceCurrencyPair } from './rules/price-currency-pair.js';
 import { countrySupported } from './rules/country-supported.js';
 import { adminLevelsValid } from './rules/admin-levels-valid.js';
@@ -17,7 +17,6 @@ export const tier2Rules: ValidationRule[] = [
   roomRanges,
   areaRange,
   coordinatesInCountry,
-  displayCoordinatesInCountry,
   priceCurrencyPair,
   adminLevelsValid,
 ];

--- a/supabase/migrations/00013_random_point_in_region.sql
+++ b/supabase/migrations/00013_random_point_in_region.sql
@@ -1,0 +1,25 @@
+-- RPC function to generate a random point inside a region's boundary polygon.
+-- Used to compute display coordinates when a scraper submits admin-level location data
+-- instead of exact coordinates.
+
+CREATE OR REPLACE FUNCTION random_point_in_region(
+  p_country_code CHAR(2),
+  p_level SMALLINT,
+  p_name TEXT
+) RETURNS TABLE(lat DOUBLE PRECISION, lng DOUBLE PRECISION) AS $$
+  WITH region AS (
+    SELECT boundary FROM admin_regions
+    WHERE country_code = p_country_code
+      AND level = p_level
+      AND name = p_name
+      AND boundary IS NOT NULL
+    LIMIT 1
+  ),
+  random_pt AS (
+    SELECT ST_GeneratePoints(boundary, 1) AS pts FROM region
+  )
+  SELECT
+    ST_Y((ST_Dump(pts)).geom) AS lat,
+    ST_X((ST_Dump(pts)).geom) AS lng
+  FROM random_pt;
+$$ LANGUAGE sql VOLATILE;

--- a/tests/fixtures/valid-listing.ts
+++ b/tests/fixtures/valid-listing.ts
@@ -20,8 +20,6 @@ export function makeValidListing(overrides: Record<string, unknown> = {}): Recor
     address_line_2: '3o Andar',
     latitude: 38.7174,
     longitude: -9.1453,
-    display_latitude: 38.7191,
-    display_longitude: -9.1438,
     location_granularity: 'coordinates',
     price_amount: 170000, // 1700.00 EUR in cents
     price_currency_code: 'EUR',


### PR DESCRIPTION
## Summary
- **Display coordinates are now write-protected server fields** — scrapers cannot set them; any submitted values are silently stripped
- Coordinates/address mode: `display = latitude/longitude`
- Admin level mode: `display = random point inside most granular admin polygon` via PostGIS `ST_GeneratePoints`
- Adds `random_point_in_region` PostGIS RPC function (migration 00013)
- Adds `ListingInsertRow` type extending `ListingInput` with required display coords
- Removes `displayCoordinatesInCountry` validation rule (no longer needed for server-set values)
- Removes `display_latitude`/`display_longitude` from input schema, required fields, and type checks

## Test plan
- [x] 25 unit tests pass
- [x] TypeScript compiles clean
- [x] Live test: listing without display coords → accepted
- [x] Live test: listing with bogus display coords (99.0) → silently ignored, accepted
- [x] Live test: admin level mode with no lat/lng → accepted
- [x] Migration 00013 pushed to Supabase
- [x] Deployed to Vercel production

🤖 Generated with [Claude Code](https://claude.com/claude-code)