### PR TITLE
Reject ocean coordinates

### DIFF
--- a/api/listings/batch.ts
+++ b/api/listings/batch.ts
@@ -10,7 +10,7 @@ import { COUNTRY_BOUNDS } from '../../src/validation/config/country-bounds.js';
 import { PRICE_RANGES } from '../../src/validation/config/price-ranges.js';
 import { loadGeographyLookup } from '../../src/validation/config/geography-lookup.js';
 import type { ListingInput } from '../../src/types/listing.js';
-import { enrichLocation, DisplayCoordinateError } from '../../src/enrichment/location-enricher.js';
+import { enrichLocation, DisplayCoordinateError, OceanCoordinateError } from '../../src/enrichment/location-enricher.js';
 
 const MAX_BATCH_SIZE = 100;
 
@@ -84,7 +84,7 @@ export default withAuth(['collection'], async (req, res) => {
         .map((r, i) => {
           if (r.status === 'fulfilled') return r.value;
           const lid = acceptedListings[i].listing_id;
-          const msg = r.reason instanceof DisplayCoordinateError
+          const msg = (r.reason instanceof DisplayCoordinateError || r.reason instanceof OceanCoordinateError)
             ? r.reason.message
             : `Enrichment failed: ${r.reason?.message ?? 'unknown error'}`;
           console.error(`Enrichment failed for ${lid}: ${msg}`);

--- a/api/listings/index.ts
+++ b/api/listings/index.ts
@@ -10,7 +10,7 @@ import { COUNTRY_BOUNDS } from '../../src/validation/config/country-bounds.js';
 import { PRICE_RANGES } from '../../src/validation/config/price-ranges.js';
 import { loadGeographyLookup } from '../../src/validation/config/geography-lookup.js';
 import type { ListingInput } from '../../src/types/listing.js';
-import { enrichLocation, DisplayCoordinateError } from '../../src/enrichment/location-enricher.js';
+import { enrichLocation, DisplayCoordinateError, OceanCoordinateError } from '../../src/enrichment/location-enricher.js';
 
 export default withAuth(['development', 'collection', 'admin'], async (req, res) => {
   try {
@@ -92,6 +92,10 @@ async function handlePost(req: VercelRequest, res: VercelResponse) {
     }
     if (err instanceof DisplayCoordinateError) {
       error(res, 'ENRICHMENT_FAILED', err.message);
+      return;
+    }
+    if (err instanceof OceanCoordinateError) {
+      error(res, 'OCEAN_COORDINATES', err.message);
       return;
     }
     throw err;

--- a/docs/listing-input.md
+++ b/docs/listing-input.md
@@ -141,5 +141,6 @@ This will pass Tier 1 and Tier 2 but will receive Tier 3 warnings for missing im
 | Price in major units instead of minor units (e.g., `1700` instead of `170000` for 1700 EUR) | `price_plausible` — the value will appear too low |
 | Using a currency that doesn't match the scraper config | `currency_matches_config` |
 | Coordinates outside the country | `coordinates_in_country` — check your lat/lng aren't swapped |
+| Coordinates in the ocean / not on land | `OCEAN_COORDINATES` — no admin region found within 10km of your coordinates |
 | Submitting a `source_url` that already exists in the database | `DUPLICATE` (409 response) — not a validation error, a storage error |
 | Using an invalid country code | `valid_iso_country` — must be ISO 3166-1 alpha-2 |

--- a/docs/validation-rules.md
+++ b/docs/validation-rules.md
@@ -117,6 +117,18 @@ If no bounding box is configured for a country, the coordinates check is skipped
 
 ---
 
+## Enrichment-Phase Checks (Hard Reject)
+
+After validation passes, listings go through location enrichment before storage. The enrichment phase can also reject listings:
+
+| Check | Field(s) | When | Error |
+|---|---|---|---|
+| `OCEAN_COORDINATES` | `latitude`, `longitude` | Coordinate mode (`coordinates`/`address`) for countries with polygon data loaded | Coordinates don't fall within any admin region polygon (even with 10km nearest-neighbor fallback). Likely in the ocean or a body of water. |
+
+These errors appear in the `storage.enrichment_errors` array in the batch response, or as a 400 `OCEAN_COORDINATES` error for single listing submissions.
+
+---
+
 ## Tier 3 — Completeness Validation (Soft Warning)
 
 Does the listing have enough data to be useful? These are **not** grounds for rejection — the listing is still stored — but they flag data quality issues.

--- a/src/enrichment/location-enricher.ts
+++ b/src/enrichment/location-enricher.ts
@@ -3,7 +3,7 @@ import type { ListingInsertRow } from '../types/listing.js';
 import type { GeocodingResult } from './geocoding.js';
 import { getGeocodingProvider } from './geocoding.js';
 import { reverseGeocodePostGIS } from './postgis-geocoder.js';
-import { getRandomPointInRegion } from '../db/admin-regions.js';
+import { getRandomPointInRegion, getAdminLevelConfig } from '../db/admin-regions.js';
 
 /**
  * Enriches location data on a listing based on what's already provided.
@@ -41,6 +41,7 @@ export async function enrichLocation(input: ListingInput): Promise<ListingInsert
       }
     }
   } catch (err) {
+    if (err instanceof OceanCoordinateError) throw err;
     console.error('Location enrichment failed, proceeding without enrichment:', err);
   }
 
@@ -86,6 +87,20 @@ async function computeDisplayCoordinates(input: ListingInput): Promise<ListingIn
   throw new DisplayCoordinateError(input.listing_id, granularity);
 }
 
+export class OceanCoordinateError extends Error {
+  constructor(
+    public readonly listingId: string,
+    public readonly lat: number,
+    public readonly lng: number,
+  ) {
+    super(
+      `Coordinates (${lat}, ${lng}) for listing ${listingId} appear to be in the ocean — ` +
+      'no admin region found within 10km. Verify your latitude and longitude are correct.',
+    );
+    this.name = 'OceanCoordinateError';
+  }
+}
+
 export class DisplayCoordinateError extends Error {
   constructor(
     public readonly listingId: string,
@@ -103,18 +118,21 @@ export class DisplayCoordinateError extends Error {
 async function enrichFromPostGIS(input: ListingInput): Promise<ListingInput> {
   if (!input.latitude || !input.longitude || !input.country_code) return input;
 
-  try {
-    const postgisResult = await reverseGeocodePostGIS(input.country_code, input.latitude, input.longitude);
-    if (postgisResult) {
-      return {
-        ...input,
-        admin_level_1: input.admin_level_1 ?? postgisResult.admin_level_1 ?? null,
-        admin_level_2: input.admin_level_2 ?? postgisResult.admin_level_2 ?? null,
-        admin_level_3: input.admin_level_3 ?? postgisResult.admin_level_3 ?? null,
-      };
-    }
-  } catch {
-    // PostGIS failed or country has no polygon data — continue without
+  const postgisResult = await reverseGeocodePostGIS(input.country_code, input.latitude, input.longitude);
+  if (postgisResult) {
+    return {
+      ...input,
+      admin_level_1: input.admin_level_1 ?? postgisResult.admin_level_1 ?? null,
+      admin_level_2: input.admin_level_2 ?? postgisResult.admin_level_2 ?? null,
+      admin_level_3: input.admin_level_3 ?? postgisResult.admin_level_3 ?? null,
+    };
+  }
+
+  // PostGIS returned null — check if this country has polygon data
+  // If it does and no region matched, the coordinates are likely in the ocean
+  const config = await getAdminLevelConfig(input.country_code);
+  if (config) {
+    throw new OceanCoordinateError(input.listing_id, input.latitude, input.longitude);
   }
 
   return input;

--- a/src/lib/notices.ts
+++ b/src/lib/notices.ts
@@ -23,6 +23,12 @@ const ALL_NOTICES: Notice[] = [
     expires: '2026-04-08',
   },
   {
+    id: 'ocean-coordinates',
+    message:
+      'Listings with coordinates that don\'t fall on land (no admin region found within 10km) are now rejected during enrichment. Verify your latitude/longitude values point to a real location.',
+    expires: '2026-04-08',
+  },
+  {
     id: 'location-mode-exclusive',
     message:
       'Location modes are now mutually exclusive. Coordinate mode (granularity "coordinates"/"address"): send only lat/lng, system backfills admin levels. Admin level mode (granularity "admin_level_*"): send only admin_level_* fields, system generates display coordinates. Sending both will be rejected.',


### PR DESCRIPTION
## Summary
- Coordinates that don't match any admin region polygon (within 10km) are now rejected with `OceanCoordinateError` during enrichment
- Catches bogus coordinates like `38.12345, -9.12345` (Atlantic Ocean) that previously stored with null admin levels
- Both batch and single endpoints handle the error gracefully — batch reports in `enrichment_errors`, single returns 400 `OCEAN_COORDINATES`

## Test plan
- [ ] Submit listing with ocean coords (38.12345, -9.12345) → rejected
- [ ] Submit listing with valid coords (38.7174, -9.1453) → accepted with admin levels backfilled
- [ ] `npm test` passes
- [ ] Notice appears in API responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)