### PR TITLE
Add validation-driven scraper health tracking

### DIFF
--- a/api/listings/batch.ts
+++ b/api/listings/batch.ts
@@ -3,7 +3,7 @@ import { withAuth } from '../../src/middleware/auth.js';
 import { handleError } from '../../src/middleware/error-handler.js';
 import { success, error } from '../../src/lib/response.js';
 import { validateBatch } from '../../src/validation/engine.js';
-import { getScraperById } from '../../src/db/scrapers.js';
+import { getScraperById, updateScraperBatchHealth } from '../../src/db/scrapers.js';
 import { insertListingsBatch } from '../../src/db/listings.js';
 import { storeRejection } from '../../src/db/rejections.js';
 import { COUNTRY_BOUNDS } from '../../src/validation/config/country-bounds.js';
@@ -98,6 +98,9 @@ export default withAuth(['collection'], async (req, res) => {
       }
     }
 
+    // Update scraper health based on validation outcomes
+    const healthResult = await updateScraperBatchHealth(configId, batchResult.summary);
+
     success(res, {
       validation: batchResult,
       storage: {
@@ -105,6 +108,12 @@ export default withAuth(['collection'], async (req, res) => {
         duplicates: insertResult.duplicates,
         ...(enrichmentErrors.length > 0 && { enrichment_errors: enrichmentErrors }),
       },
+      ...(healthResult?.status_changed_to && {
+        scraper_health: {
+          acceptance_rate: healthResult.acceptance_rate,
+          status_changed_to: healthResult.status_changed_to,
+        },
+      }),
     }, 201);
   } catch (err) {
     handleError(res, err);

--- a/api/scrapers/[id]/run.ts
+++ b/api/scrapers/[id]/run.ts
@@ -28,12 +28,10 @@ export default withAuth(['collection'], async (req, res) => {
     // Store the run receipt
     const receipt = await storeRunReceipt(configId, parsed.data);
 
-    // Update scraper registry
-    const failureAction = parsed.data.status === 'success' ? 'reset' : 'increment';
+    // Update scraper registry (heartbeat + run metadata)
     const result = await updateScraperRunResult(configId, {
       status: parsed.data.status,
       listings_accepted: parsed.data.listings_accepted,
-      failure_count_action: failureAction,
     });
 
     if (!result) {

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -291,10 +291,23 @@ Validate and store multiple listings in one request.
     "storage": {
       "inserted": 35,
       "duplicates": ["https://example.com/listing/old"]
+    },
+    "scraper_health": {
+      "acceptance_rate": 0.7,
+      "status_changed_to": "degraded"
     }
   }
 }
 ```
+
+The `scraper_health` field is only included when a status transition occurs (e.g., `active` → `degraded`, `degraded` → `active`, `degraded` → `broken`). It contains:
+
+| Field | Type | Description |
+|---|---|---|
+| `acceptance_rate` | number | Acceptance rate for this batch (0.0 - 1.0) |
+| `status_changed_to` | string | The new status the scraper transitioned to |
+
+See [Validation Rules — Scraper Health Tracking](./validation-rules.md#scraper-health-tracking) for threshold details.
 
 ---
 
@@ -558,7 +571,7 @@ Query the scraper registry.
 
 | Parameter | Type | Description |
 |---|---|---|
-| `status` | string | `active`, `paused`, `broken`, `testing` |
+| `status` | string | `active`, `paused`, `broken`, `testing`, `degraded` |
 | `country_code` | string | ISO 3166-1 alpha-2 code |
 | `listing_type` | string | `sale` or `rent` |
 | `limit` | integer | Results per page (default: 50) |
@@ -585,6 +598,12 @@ Query the scraper registry.
         "failure_count": 0,
         "broken_at": null,
         "repair_count": 0,
+        "acceptance_rate": 0.95,
+        "last_batch_at": "2026-03-25T06:01:30Z",
+        "last_batch_submitted": 47,
+        "last_batch_accepted": 45,
+        "top_rejection_rule": "price_plausible",
+        "degraded_at": null,
         "config": { "currency_code": "EUR", ... }
       }
     ],
@@ -663,9 +682,9 @@ Record the results of a scraper run. Creates a run receipt and updates the scrap
 | `error_message` | string | No | Error details if the run failed |
 
 **Automatic behaviors:**
-- On `success`: resets `failure_count` to 0.
-- On `partial` or `failure`: increments `failure_count`.
-- After 3 consecutive failures: automatically sets scraper status to `broken`.
+- Updates `last_run_at` (heartbeat), `last_run_status`, and `last_run_listings`.
+- This endpoint acts as a check-in — it resets the 24-hour staleness timer. Scrapers that don't check in (via this endpoint or the batch endpoint) for 24 hours are automatically marked `broken` by a daily cron job.
+- This endpoint does **not** drive status transitions. Quality-based health tracking is handled by the batch endpoint.
 
 **Response (200):**
 
@@ -674,8 +693,7 @@ Record the results of a scraper run. Creates a run receipt and updates the scrap
   "success": true,
   "data": {
     "receipt_id": "...",
-    "updated": true,
-    "failure_count": 0
+    "updated": true
   }
 }
 ```
@@ -699,10 +717,10 @@ Update a scraper's status. Use this to reactivate a repaired scraper.
 }
 ```
 
-**Valid values:** `active`, `paused`, `broken`, `testing`
+**Valid values:** `active`, `paused`, `broken`, `testing`, `degraded`
 
 **Automatic behaviors:**
-- When changing from `broken` or `testing` to `active`: increments `repair_count` and resets `failure_count` to 0.
+- When changing from `broken`, `degraded`, or `testing` to `active`: increments `repair_count`, resets `failure_count` to 0, and clears `degraded_at`.
 
 ---
 

--- a/docs/validation-rules.md
+++ b/docs/validation-rules.md
@@ -183,6 +183,43 @@ Each error/warning object:
 
 ---
 
+## Scraper Health Tracking
+
+The batch endpoint (`POST /api/listings/batch`) automatically tracks scraper health based on validation outcomes. Health metrics are written to the `scraper_registry` after every batch.
+
+### Quality thresholds
+
+| Acceptance Rate | Transition | Rationale |
+|---|---|---|
+| >= 70% | Stay `active`, or `degraded` → `active` (auto-recover) | Healthy batch |
+| < 70% and >= 30% | `active` → `degraded` | Significant quality drop, still producing some data |
+| < 30% | `active`/`degraded` → `broken` | Extracting garbage |
+
+**Minimum batch size guard:** Batches with fewer than 3 listings skip state transitions (not statistically meaningful). Health columns are still updated.
+
+### Staleness detection
+
+Every active or degraded scraper must check in at least once per day — either via the batch endpoint (submitting listings) or the run endpoint (reporting a run result). A daily cron job (03:30 UTC) marks stale scrapers as `broken`.
+
+`testing` and `paused` scrapers are excluded from both quality and staleness checks.
+
+### Recovery
+
+When a `degraded` scraper submits a healthy batch (>= 70% acceptance rate), it automatically recovers to `active`. `broken` scrapers require a manual status change via `PATCH /api/scrapers/{id}/status`.
+
+### Health columns in scraper registry
+
+| Column | Type | Description |
+|---|---|---|
+| `acceptance_rate` | real | Acceptance rate from the most recent batch (0.0 - 1.0) |
+| `last_batch_at` | timestamptz | When the last batch was processed |
+| `last_batch_submitted` | integer | Number of listings submitted in the last batch |
+| `last_batch_accepted` | integer | Number of listings accepted in the last batch |
+| `top_rejection_rule` | varchar(100) | Most common rejection rule in the last batch |
+| `degraded_at` | timestamptz | When the scraper entered `degraded` status |
+
+---
+
 ## Adding New Rules
 
 To add a new validation rule:

--- a/src/db/scrapers.ts
+++ b/src/db/scrapers.ts
@@ -1,5 +1,6 @@
 import { getSupabaseClient } from './client.js';
 import type { ScraperRegistryInput } from '../types/scraper.js';
+import type { BatchSummary } from '../types/validation.js';
 
 export async function registerScraper(input: ScraperRegistryInput) {
   const client = getSupabaseClient();
@@ -63,29 +64,16 @@ export async function updateScraperRunResult(
   runResult: {
     status: string;
     listings_accepted?: number;
-    failure_count_action: 'increment' | 'reset';
   },
 ) {
   const client = getSupabaseClient();
   const now = new Date().toISOString();
 
-  // Fetch current to handle failure_count logic
-  const existing = await getScraperById(configId);
-  if (!existing) return null;
-
-  const newFailureCount = runResult.failure_count_action === 'reset' ? 0 : existing.failure_count + 1;
   const updates: Record<string, unknown> = {
     last_run_at: now,
     last_run_status: runResult.status,
     last_run_listings: runResult.listings_accepted ?? null,
-    failure_count: newFailureCount,
   };
-
-  // Auto-mark as broken after 3 consecutive failures
-  if (newFailureCount >= 3 && existing.status === 'active') {
-    updates.status = 'broken';
-    updates.broken_at = now;
-  }
 
   const { error } = await client
     .from('scraper_registry')
@@ -93,7 +81,7 @@ export async function updateScraperRunResult(
     .eq('config_id', configId);
 
   if (error) throw new Error(`Failed to update scraper run result: ${error.message}`);
-  return { updated: true, failure_count: newFailureCount };
+  return { updated: true };
 }
 
 export async function updateScraperStatus(configId: string, newStatus: string) {
@@ -103,10 +91,11 @@ export async function updateScraperStatus(configId: string, newStatus: string) {
 
   const updates: Record<string, unknown> = { status: newStatus };
 
-  // Track repairs: if moving from broken/testing to active, increment repair_count
-  if (newStatus === 'active' && (existing.status === 'broken' || existing.status === 'testing')) {
+  // Track repairs: if moving from broken/degraded/testing to active, increment repair_count
+  if (newStatus === 'active' && (existing.status === 'broken' || existing.status === 'degraded' || existing.status === 'testing')) {
     updates.repair_count = existing.repair_count + 1;
     updates.failure_count = 0;
+    updates.degraded_at = null;
   }
 
   const { error } = await client
@@ -116,4 +105,79 @@ export async function updateScraperStatus(configId: string, newStatus: string) {
 
   if (error) throw new Error(`Failed to update scraper status: ${error.message}`);
   return { updated: true };
+}
+
+const MIN_BATCH_SIZE = 3;
+const DEGRADE_THRESHOLD = 0.7;
+const BREAK_THRESHOLD = 0.3;
+
+export async function updateScraperBatchHealth(
+  configId: string,
+  summary: BatchSummary,
+) {
+  const client = getSupabaseClient();
+  const existing = await getScraperById(configId);
+  if (!existing) return null;
+
+  // Skip health updates for paused/testing scrapers
+  if (existing.status === 'paused' || existing.status === 'testing') {
+    return { updated: false, acceptance_rate: null, status_changed_to: null };
+  }
+
+  const totalAccepted = summary.accepted + summary.accepted_with_warnings;
+  const rate = summary.total_submitted > 0
+    ? totalAccepted / summary.total_submitted
+    : 0;
+  const topRule = summary.top_rejection_reasons[0]?.rule ?? null;
+  const now = new Date().toISOString();
+
+  const updates: Record<string, unknown> = {
+    acceptance_rate: Math.round(rate * 1000) / 1000,
+    last_batch_at: now,
+    last_batch_submitted: summary.total_submitted,
+    last_batch_accepted: totalAccepted,
+    top_rejection_rule: topRule,
+  };
+
+  let statusChangedTo: string | null = null;
+
+  // Only trigger state changes for meaningful batch sizes
+  if (summary.total_submitted >= MIN_BATCH_SIZE) {
+    if (rate >= DEGRADE_THRESHOLD) {
+      // Healthy — recover if degraded
+      if (existing.status === 'degraded') {
+        updates.status = 'active';
+        updates.degraded_at = null;
+        statusChangedTo = 'active';
+      }
+    } else if (rate >= BREAK_THRESHOLD) {
+      // Degraded
+      if (existing.status === 'active') {
+        updates.status = 'degraded';
+        updates.degraded_at = now;
+        statusChangedTo = 'degraded';
+      }
+    } else {
+      // Broken — acceptance rate below 0.3
+      if (existing.status === 'active' || existing.status === 'degraded') {
+        updates.status = 'broken';
+        updates.broken_at = now;
+        updates.degraded_at = existing.degraded_at ?? now;
+        statusChangedTo = 'broken';
+      }
+    }
+  }
+
+  const { error } = await client
+    .from('scraper_registry')
+    .update(updates)
+    .eq('config_id', configId);
+
+  if (error) throw new Error(`Failed to update scraper batch health: ${error.message}`);
+
+  return {
+    updated: true,
+    acceptance_rate: Math.round(rate * 1000) / 1000,
+    status_changed_to: statusChangedTo,
+  };
 }

--- a/src/lib/notices.ts
+++ b/src/lib/notices.ts
@@ -40,6 +40,12 @@ const ALL_NOTICES: Notice[] = [
       'Greece (GR) is now supported. Listings can be submitted with country_code "GR" — admin levels are validated against official administrative boundaries (Region → Regional Unit → Municipality). Both Latin transliterations and Greek script names are accepted.',
     expires: '2026-04-09',
   },
+  {
+    id: 'scraper-health-tracking',
+    message:
+      'The batch endpoint now tracks scraper health based on validation outcomes. Scrapers with acceptance rate below 70% are marked "degraded", below 30% "broken". Scrapers that don\'t check in for 24 hours are auto-marked "broken". Auto-recovery occurs when a healthy batch (>= 70% acceptance) is submitted. Query the scraper registry for acceptance_rate and top_rejection_rule fields.',
+    expires: '2026-04-09',
+  },
 ];
 
 export function getActiveNotices(): string[] {

--- a/src/types/operations.ts
+++ b/src/types/operations.ts
@@ -34,7 +34,7 @@ export type RunResultInput = z.infer<typeof RunResultSchema>;
 
 // Scraper status update
 export const ScraperStatusUpdateSchema = z.object({
-  status: z.enum(['active', 'paused', 'broken', 'testing']),
+  status: z.enum(['active', 'paused', 'broken', 'testing', 'degraded']),
 });
 
 export type ScraperStatusUpdateInput = z.infer<typeof ScraperStatusUpdateSchema>;

--- a/src/types/scraper.ts
+++ b/src/types/scraper.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-export const SCRAPER_STATUSES = ['active', 'paused', 'broken', 'testing'] as const;
+export const SCRAPER_STATUSES = ['active', 'paused', 'broken', 'testing', 'degraded'] as const;
 export const RUN_STATUSES = ['success', 'partial', 'failure'] as const;
 
 export type ScraperStatus = (typeof SCRAPER_STATUSES)[number];
@@ -31,4 +31,10 @@ export interface ScraperRow {
   broken_at: string | null;
   repair_count: number;
   config: Record<string, unknown>;
+  acceptance_rate: number | null;
+  last_batch_at: string | null;
+  last_batch_submitted: number | null;
+  last_batch_accepted: number | null;
+  top_rejection_rule: string | null;
+  degraded_at: string | null;
 }

--- a/supabase/migrations/00017_scraper_health_columns.sql
+++ b/supabase/migrations/00017_scraper_health_columns.sql
@@ -1,0 +1,35 @@
+-- Add 'degraded' status and quality health columns to scraper_registry.
+-- Also adds a daily cron job to mark stale scrapers as broken.
+
+-- 1. Add 'degraded' to the status enum
+ALTER TABLE scraper_registry
+  DROP CONSTRAINT scraper_registry_status_check,
+  ADD CONSTRAINT scraper_registry_status_check
+    CHECK (status IN ('active', 'paused', 'broken', 'testing', 'degraded'));
+
+-- 2. Add quality health columns (written by batch endpoint)
+ALTER TABLE scraper_registry
+  ADD COLUMN acceptance_rate REAL,
+  ADD COLUMN last_batch_at TIMESTAMPTZ,
+  ADD COLUMN last_batch_submitted INTEGER,
+  ADD COLUMN last_batch_accepted INTEGER,
+  ADD COLUMN top_rejection_rule VARCHAR(100),
+  ADD COLUMN degraded_at TIMESTAMPTZ;
+
+-- 3. Staleness detection: mark active/degraded scrapers as broken if no check-in for 24h.
+-- "Check-in" = whichever is more recent of last_batch_at (batch endpoint) or last_run_at (run endpoint).
+-- Runs daily at 03:30 UTC, after existing retention jobs.
+SELECT cron.schedule(
+  'mark_stale_scrapers_broken',
+  '30 3 * * *',
+  $$
+    UPDATE scraper_registry
+    SET status = 'broken',
+        broken_at = now()
+    WHERE status IN ('active', 'degraded')
+      AND GREATEST(
+            COALESCE(last_batch_at, '1970-01-01'),
+            COALESCE(last_run_at, '1970-01-01')
+          ) < now() - INTERVAL '24 hours'
+  $$
+);


### PR DESCRIPTION
## Summary
- Batch endpoint now computes acceptance rate per batch and drives scraper status transitions (`active` ↔ `degraded` → `broken`)
- New `degraded` status for scrapers with acceptance rate between 30–70% — still collecting data but flagged for attention
- Daily pg_cron job marks stale scrapers (no check-in for 24h) as `broken`
- Run endpoint simplified to heartbeat + receipt storage (no longer drives status transitions)
- New health columns on `scraper_registry`: `acceptance_rate`, `last_batch_at`, `last_batch_submitted`, `last_batch_accepted`, `top_rejection_rule`, `degraded_at`

## Test plan
- [x] `npx tsc --noEmit` passes
- [x] All 33 tests pass
- [x] Migration 00017 applied to Supabase
- [ ] Deploy to Vercel (token expired — needs `vercel login`)
- [ ] Smoke test: submit healthy batch → acceptance_rate ~1.0, status stays `active`
- [ ] Smoke test: submit degraded batch → status → `degraded`
- [ ] Smoke test: submit healthy batch after degraded → auto-recover to `active`
- [ ] Verify `scraper_health` field in batch response on status transition
- [ ] Verify `mark_stale_scrapers_broken` cron job registered in `cron.job`

🤖 Generated with [Claude Code](https://claude.com/claude-code)