### PR TITLE
Add reader role for read-only API access

### DIFF
--- a/api/geography/[country_code].ts
+++ b/api/geography/[country_code].ts
@@ -36,7 +36,7 @@ function buildTree(regions: AdminRegion[]): RegionNode[] {
   return roots;
 }
 
-export default withAuth(['development', 'collection'], async (req, res) => {
+export default withAuth(['development', 'collection', 'reader'], async (req, res) => {
   if (req.method !== 'GET') {
     error(res, 'METHOD_NOT_ALLOWED', 'Only GET is allowed', 405);
     return;

--- a/api/geography/[country_code]/search.ts
+++ b/api/geography/[country_code]/search.ts
@@ -23,7 +23,7 @@ function buildPath(region: AdminRegion, byId: Map<number, AdminRegion>): string 
   return parts.join(' > ');
 }
 
-export default withAuth(['development', 'collection'], async (req, res) => {
+export default withAuth(['development', 'collection', 'reader'], async (req, res) => {
   if (req.method !== 'GET') {
     error(res, 'METHOD_NOT_ALLOWED', 'Only GET is allowed', 405);
     return;

--- a/api/listings/index.ts
+++ b/api/listings/index.ts
@@ -12,7 +12,7 @@ import { loadGeographyLookup } from '../../src/validation/config/geography-looku
 import type { ListingInput } from '../../src/types/listing.js';
 import { enrichLocation, DisplayCoordinateError, OceanCoordinateError } from '../../src/enrichment/location-enricher.js';
 
-export default withAuth(['development', 'collection', 'admin'], async (req, res) => {
+export default withAuth(['development', 'collection', 'admin', 'reader'], async (req, res) => {
   try {
     if (req.method === 'GET') {
       return await handleGet(req, res);

--- a/api/rejections/index.ts
+++ b/api/rejections/index.ts
@@ -4,7 +4,7 @@ import { handleError } from '../../src/middleware/error-handler.js';
 import { success, error } from '../../src/lib/response.js';
 import { queryRejections } from '../../src/db/rejections.js';
 
-export default withAuth(['development', 'admin'], async (req, res) => {
+export default withAuth(['development', 'admin', 'reader'], async (req, res) => {
   if (req.method !== 'GET') {
     error(res, 'METHOD_NOT_ALLOWED', 'Only GET is allowed', 405);
     return;

--- a/api/rejections/summary.ts
+++ b/api/rejections/summary.ts
@@ -4,7 +4,7 @@ import { handleError } from '../../src/middleware/error-handler.js';
 import { success, error } from '../../src/lib/response.js';
 import { getRejectionSummary } from '../../src/db/rejections.js';
 
-export default withAuth(['development', 'collection', 'admin'], async (req, res) => {
+export default withAuth(['development', 'collection', 'admin', 'reader'], async (req, res) => {
   if (req.method !== 'GET') {
     error(res, 'METHOD_NOT_ALLOWED', 'Only GET is allowed', 405);
     return;

--- a/api/run-receipts/index.ts
+++ b/api/run-receipts/index.ts
@@ -4,7 +4,7 @@ import { handleError } from '../../src/middleware/error-handler.js';
 import { success, error } from '../../src/lib/response.js';
 import { queryRunReceipts } from '../../src/db/run-receipts.js';
 
-export default withAuth(['development', 'collection', 'admin'], async (req, res) => {
+export default withAuth(['development', 'collection', 'admin', 'reader'], async (req, res) => {
   if (req.method !== 'GET') {
     error(res, 'METHOD_NOT_ALLOWED', 'Only GET is allowed', 405);
     return;

--- a/api/scrapers/index.ts
+++ b/api/scrapers/index.ts
@@ -4,7 +4,7 @@ import { handleError } from '../../src/middleware/error-handler.js';
 import { success, error } from '../../src/lib/response.js';
 import { queryScrapers } from '../../src/db/scrapers.js';
 
-export default withAuth(['development', 'collection', 'admin'], async (req, res) => {
+export default withAuth(['development', 'collection', 'admin', 'reader'], async (req, res) => {
   if (req.method !== 'GET') {
     error(res, 'METHOD_NOT_ALLOWED', 'Only GET is allowed', 405);
     return;

--- a/api/search/execute.ts
+++ b/api/search/execute.ts
@@ -5,7 +5,7 @@ import { success, error } from '../../src/lib/response.js';
 import { ExecuteQuerySchema } from '../../src/types/search.js';
 import { executeReadonlyQuery } from '../../src/db/search.js';
 
-export default withAuth(['admin'], async (req, res) => {
+export default withAuth(['admin', 'reader'], async (req, res) => {
   if (req.method !== 'POST') {
     error(res, 'METHOD_NOT_ALLOWED', 'Only POST is allowed', 405);
     return;

--- a/api/search/schema.ts
+++ b/api/search/schema.ts
@@ -4,7 +4,7 @@ import { handleError } from '../../src/middleware/error-handler.js';
 import { success, error } from '../../src/lib/response.js';
 import { getTableSchema } from '../../src/db/search.js';
 
-export default withAuth(['admin'], async (req, res) => {
+export default withAuth(['admin', 'reader'], async (req, res) => {
   if (req.method !== 'GET') {
     error(res, 'METHOD_NOT_ALLOWED', 'Only GET is allowed', 405);
     return;

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -16,13 +16,14 @@ All endpoints require a JWT Bearer token in the `Authorization` header.
 Authorization: Bearer <token>
 ```
 
-The JWT must contain an `app_role` claim with one of three values:
+The JWT must contain an `app_role` claim with one of four values:
 
 | Role | Description | Typical consumer |
 |---|---|---|
 | `development` | Build and test scrapers | Scraper-building agents |
 | `collection` | Submit live data and manage runs | Collection layer / orchestrator |
 | `admin` | Full read access, manage registry | Owner / dashboard |
+| `reader` | Read-only access to GET endpoints and search | AI agents / external consumers |
 
 Tokens are verified against the `SUPABASE_JWT_SECRET` environment variable using the HS256 algorithm.
 
@@ -317,7 +318,7 @@ The `scraper_health` field is **always** included in the batch response. It eval
 
 Query stored listings with optional filters.
 
-**Role:** `development`, `collection`, `admin`
+**Role:** `development`, `collection`, `admin`, `reader`
 
 **Query parameters:**
 
@@ -453,7 +454,7 @@ Update the status of an existing listing.
 
 Browse the admin region hierarchy for a supported country. Returns the full region tree by default, or a filtered subset.
 
-**Role:** `development`, `collection`
+**Role:** `development`, `collection`, `reader`
 
 **Path parameters:**
 - `country_code` — ISO 3166-1 alpha-2 code (e.g., `PT`).
@@ -527,7 +528,7 @@ If neither `level` nor `parent` is provided, the full hierarchy tree is returned
 
 Fuzzy-search for regions within a country. Returns matching regions with their full ancestry path.
 
-**Role:** `development`, `collection`
+**Role:** `development`, `collection`, `reader`
 
 **Path parameters:**
 - `country_code` — ISO 3166-1 alpha-2 code.
@@ -567,7 +568,7 @@ Fuzzy-search for regions within a country. Returns matching regions with their f
 
 Query the scraper registry.
 
-**Role:** `development`, `collection`, `admin`
+**Role:** `development`, `collection`, `admin`, `reader`
 
 **Query parameters:**
 
@@ -819,7 +820,7 @@ Update a scraper's status. Use this to reactivate a repaired scraper.
 
 Query recent rejection records.
 
-**Role:** `development`, `admin`
+**Role:** `development`, `admin`, `reader`
 
 **Query parameters:**
 
@@ -863,7 +864,7 @@ Query recent rejection records.
 
 Get aggregate rejection statistics.
 
-**Role:** `development`, `collection`, `admin`
+**Role:** `development`, `collection`, `admin`, `reader`
 
 **Query parameters:**
 
@@ -895,7 +896,7 @@ Get aggregate rejection statistics.
 
 Query run receipts for recent scraper runs.
 
-**Role:** `development`, `collection`, `admin`
+**Role:** `development`, `collection`, `admin`, `reader`
 
 **Query parameters:**
 
@@ -914,7 +915,7 @@ Query run receipts for recent scraper runs.
 
 ## Search (Read-Only SQL)
 
-The search endpoints give admin-role consumers (e.g., AI agents) the ability to run arbitrary read-only SQL queries against the full database. This enables flexible analytics, custom filtering, cross-table joins, aggregations, and PostGIS spatial queries.
+The search endpoints give admin- and reader-role consumers (e.g., AI agents) the ability to run arbitrary read-only SQL queries against the full database. This enables flexible analytics, custom filtering, cross-table joins, aggregations, and PostGIS spatial queries.
 
 For the complete reference — including the full database schema, all enum values, spatial query patterns, and 15+ example queries — see **[docs/search-guide.md](search-guide.md)**.
 
@@ -922,7 +923,7 @@ For the complete reference — including the full database schema, all enum valu
 
 Execute a read-only SQL query. Returns results as a JSON array.
 
-**Roles:** `admin`
+**Roles:** `admin`, `reader`
 
 **Request body:**
 
@@ -940,7 +941,7 @@ Execute a read-only SQL query. Returns results as a JSON array.
 
 Returns column metadata (names, types, nullability) for all queryable tables.
 
-**Roles:** `admin`
+**Roles:** `admin`, `reader`
 
 **Response:** Array of `{ "table_name": "...", "columns": [...] }`
 
@@ -953,21 +954,21 @@ Returns column metadata (names, types, nullability) for all queryable tables.
 | `/api/validate/test` | POST | development | Validate without storing |
 | `/api/validate/test-batch` | POST | development | Batch validate without storing |
 | `/api/validate/replay/{id}` | POST | development | Re-validate a previous rejection |
-| `/api/listings` | GET | development, collection, admin | Query stored listings |
+| `/api/listings` | GET | development, collection, admin, reader | Query stored listings |
 | `/api/listings` | POST | collection | Validate + store a listing |
 | `/api/listings/batch` | POST | collection | Batch validate + store |
 | `/api/listings/check-urls` | POST | collection | Check URLs for duplicates |
 | `/api/listings/{id}/price` | PATCH | collection | Update price (auto history) |
 | `/api/listings/{id}/status` | PATCH | collection | Update listing status |
-| `/api/geography/:country_code` | GET | development, collection | Browse admin region hierarchy |
-| `/api/geography/:country_code/search` | GET | development, collection | Fuzzy-search for regions |
-| `/api/scrapers` | GET | development, collection, admin | Query scraper registry |
+| `/api/geography/:country_code` | GET | development, collection, reader | Browse admin region hierarchy |
+| `/api/geography/:country_code/search` | GET | development, collection, reader | Fuzzy-search for regions |
+| `/api/scrapers` | GET | development, collection, admin, reader | Query scraper registry |
 | `/api/scrapers/register` | POST | development | Register a new scraper |
 | `/api/scrapers/{id}/config` | PATCH | development, admin | Update scraper config fields |
 | `/api/scrapers/{id}/run` | PATCH | collection | Record run results |
 | `/api/scrapers/{id}/status` | PATCH | development, admin | Update scraper status |
-| `/api/rejections` | GET | development, admin | Query rejection records |
-| `/api/rejections/summary` | GET | development, collection, admin | Rejection statistics |
-| `/api/run-receipts` | GET | development, collection, admin | Query run receipts |
-| `/api/search/execute` | POST | admin | Execute read-only SQL query |
-| `/api/search/schema` | GET | admin | Get table/column metadata |
+| `/api/rejections` | GET | development, admin, reader | Query rejection records |
+| `/api/rejections/summary` | GET | development, collection, admin, reader | Rejection statistics |
+| `/api/run-receipts` | GET | development, collection, admin, reader | Query run receipts |
+| `/api/search/execute` | POST | admin, reader | Execute read-only SQL query |
+| `/api/search/schema` | GET | admin, reader | Get table/column metadata |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -53,7 +53,7 @@ vercel deploy
 
 API consumers authenticate with JWTs that contain an `app_role` claim. To create a key:
 
-1. Choose the appropriate role: `development`, `collection`, or `admin`.
+1. Choose the appropriate role: `development`, `collection`, `admin`, or `reader`. Use `reader` for AI agents and external consumers that only need to query data.
 2. Generate a JWT signed with your `SUPABASE_JWT_SECRET` (HS256) containing:
 
 ```json

--- a/docs/search-guide.md
+++ b/docs/search-guide.md
@@ -25,7 +25,7 @@ You have **read-only SQL access** to all of this data via two API endpoints.
 
 Execute an arbitrary read-only SQL query.
 
-**Auth:** `admin` role only (JWT Bearer token with `app_role: "admin"`)
+**Auth:** `admin` or `reader` role (JWT Bearer token with `app_role: "admin"` or `"reader"`)
 
 **Request:**
 
@@ -63,7 +63,7 @@ Execute an arbitrary read-only SQL query.
 |--------|------|-------|
 | 400 | `INVALID_REQUEST` | Missing or invalid `sql` field |
 | 401 | `UNAUTHORIZED` | Missing or invalid token |
-| 403 | `FORBIDDEN` | Token role is not `admin` |
+| 403 | `FORBIDDEN` | Token role is not `admin` or `reader` |
 | 500 | `INTERNAL_ERROR` | Query execution failed (prohibited keyword, timeout, syntax error, etc.) |
 
 The error message from the database is included, so you can see whether it was a syntax error, a prohibited keyword, or a timeout.
@@ -72,7 +72,7 @@ The error message from the database is included, so you can see whether it was a
 
 Returns column metadata for all queryable tables. Useful for discovering column names and types before writing SQL.
 
-**Auth:** `admin` role only
+**Auth:** `admin` or `reader` role
 
 **Response:**
 

--- a/src/lib/notices.ts
+++ b/src/lib/notices.ts
@@ -67,7 +67,13 @@ const ALL_NOTICES: Notice[] = [
   {
     id: 'search-endpoints',
     message:
-      'New search endpoints (admin role only): POST /api/search/execute accepts {"sql": "SELECT ..."} for read-only SQL queries against the database (5s timeout, 500-row limit). GET /api/search/schema returns table/column metadata. See docs/search-guide.md for full reference.',
+      'Search endpoints (admin and reader roles): POST /api/search/execute accepts {"sql": "SELECT ..."} for read-only SQL queries against the database (5s timeout, 500-row limit). GET /api/search/schema returns table/column metadata. See docs/search-guide.md for full reference.',
+    expires: '2026-04-19',
+  },
+  {
+    id: 'reader-role',
+    message:
+      'New "reader" role provides read-only access to all GET endpoints and search endpoints. Use this role for AI agents and external consumers that only need to query data. Search endpoints no longer require admin role.',
     expires: '2026-04-19',
   },
 ];

--- a/src/middleware/auth.ts
+++ b/src/middleware/auth.ts
@@ -54,5 +54,5 @@ async function extractRole(token: string): Promise<AppRole | null> {
 }
 
 function isValidRole(role: string): role is AppRole {
-  return ['development', 'collection', 'admin'].includes(role);
+  return ['development', 'collection', 'admin', 'reader'].includes(role);
 }

--- a/src/types/api.ts
+++ b/src/types/api.ts
@@ -9,7 +9,7 @@ export interface ApiResponse<T = unknown> {
   notices?: string[];
 }
 
-export type AppRole = 'development' | 'collection' | 'admin';
+export type AppRole = 'development' | 'collection' | 'admin' | 'reader';
 
 export interface AuthenticatedRequest {
   appRole: AppRole;


### PR DESCRIPTION
## Summary
- Adds a new `reader` role that grants read-only access to all GET endpoints and both search endpoints (`POST /api/search/execute`, `GET /api/search/schema`)
- Blocks `reader` from all write/mutation endpoints (POST listings, PATCH price/status, scraper registration, etc.)
- Updates notices, API reference, search guide, and quickstart docs

## Test plan
- [x] `npx tsc --noEmit` — no type errors
- [x] `npm test` — all 63 tests pass
- [ ] Deploy and verify reader JWT gets 200 on search endpoints
- [ ] Verify reader JWT gets 403 on POST/PATCH mutation endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)