### PR TITLE
Fix search execute rejecting all valid SQL queries

### DIFF
--- a/supabase/migrations/00022_fix_search_regex_escaping.sql
+++ b/supabase/migrations/00022_fix_search_regex_escaping.sql
@@ -1,0 +1,42 @@
+-- Fix: word boundary regex used \b (PCRE) but PostgreSQL uses POSIX regex
+-- which requires \y for word boundaries. Also fix \s+ escaping inside $$.
+-- Both the SELECT/WITH check and the DML keyword blocklist were affected.
+
+CREATE OR REPLACE FUNCTION execute_readonly_query(query_text TEXT)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET statement_timeout = '5s'
+AS $$
+DECLARE
+  result JSONB;
+  normalized TEXT;
+BEGIN
+  -- Normalize: collapse whitespace, trim, uppercase for keyword check
+  normalized := upper(btrim(regexp_replace(query_text, '\s+', ' ', 'g')));
+
+  -- Must start with SELECT or WITH (\y = word boundary in POSIX regex)
+  IF normalized !~ '^(SELECT|WITH)\y' THEN
+    RAISE EXCEPTION 'Only SELECT and WITH...SELECT statements are allowed';
+  END IF;
+
+  -- Block DML/DDL keywords
+  IF normalized ~ '\y(INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|TRUNCATE|GRANT|REVOKE|COPY)\y' THEN
+    RAISE EXCEPTION 'Statement contains a prohibited keyword';
+  END IF;
+
+  -- Engine-level read-only enforcement (belt-and-suspenders)
+  SET LOCAL transaction_read_only = on;
+
+  -- Inject LIMIT if not present
+  IF normalized NOT LIKE '%LIMIT %' THEN
+    query_text := query_text || ' LIMIT 500';
+  END IF;
+
+  -- Execute and return as JSON array
+  EXECUTE 'SELECT COALESCE(jsonb_agg(row_to_json(t)), ''[]''::jsonb) FROM (' || query_text || ') t'
+  INTO result;
+
+  RETURN result;
+END;
+$$;

--- a/supabase/migrations/00023_fix_search_word_boundary_regex.sql
+++ b/supabase/migrations/00023_fix_search_word_boundary_regex.sql
@@ -1,0 +1,42 @@
+-- Fix: PostgreSQL uses POSIX regex, not PCRE. \b (word boundary) is not
+-- supported — must use \y instead. This caused the SELECT/WITH check and
+-- DML keyword blocklist to never match, rejecting all queries.
+
+CREATE OR REPLACE FUNCTION execute_readonly_query(query_text TEXT)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET statement_timeout = '5s'
+AS $$
+DECLARE
+  result JSONB;
+  normalized TEXT;
+BEGIN
+  -- Normalize: collapse whitespace, trim, uppercase for keyword check
+  normalized := upper(btrim(regexp_replace(query_text, '\s+', ' ', 'g')));
+
+  -- Must start with SELECT or WITH (\y = word boundary in POSIX regex)
+  IF normalized !~ '^(SELECT|WITH)\y' THEN
+    RAISE EXCEPTION 'Only SELECT and WITH...SELECT statements are allowed';
+  END IF;
+
+  -- Block DML/DDL keywords
+  IF normalized ~ '\y(INSERT|UPDATE|DELETE|DROP|ALTER|CREATE|TRUNCATE|GRANT|REVOKE|COPY)\y' THEN
+    RAISE EXCEPTION 'Statement contains a prohibited keyword';
+  END IF;
+
+  -- Engine-level read-only enforcement (belt-and-suspenders)
+  SET LOCAL transaction_read_only = on;
+
+  -- Inject LIMIT if not present
+  IF normalized NOT LIKE '%LIMIT %' THEN
+    query_text := query_text || ' LIMIT 500';
+  END IF;
+
+  -- Execute and return as JSON array
+  EXECUTE 'SELECT COALESCE(jsonb_agg(row_to_json(t)), ''[]''::jsonb) FROM (' || query_text || ') t'
+  INTO result;
+
+  RETURN result;
+END;
+$$;


### PR DESCRIPTION
## Summary
- The `execute_readonly_query` Postgres function used `\b` for word boundaries, but PostgreSQL uses POSIX regex which requires `\y`
- This caused the `SELECT`/`WITH` validation check to never match, rejecting every query with "Only SELECT and WITH...SELECT statements are allowed"
- Migration 00023 replaces all `\b` with `\y` in both the SELECT check and DML keyword blocklist

## Test plan
- [x] `SELECT 1 as test` returns `{"rows": [{"test": 1}], "row_count": 1}`
- [x] `SELECT listing_id, title, price_amount FROM listings LIMIT 3` returns real data
- [x] `DELETE FROM listings` is correctly rejected
- [x] Migration already applied to production Supabase

Fixes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)