### PR TITLE
Enforce non-empty titles end-to-end

### DIFF
--- a/docs/listing-input.md
+++ b/docs/listing-input.md
@@ -53,7 +53,7 @@ This is the object that scrapers produce and submit to the API. It is the contra
 | `property_subtype` | string (max 100) or null | No | Market-specific subtype (e.g., `single_family`, `condo`, `riad`). |
 | `raw_property_type` | string (max 500) or null | No | Exact source text. |
 | **Content** | | | |
-| `title` | string (max 500) | Yes | Listing title or headline. Must be non-empty. |
+| `title` | string (max 500) | Yes | Listing title or headline. Trimmed before validation; must be non-empty after trimming. |
 | `description` | string or null | No | Raw description. Any language, any length. |
 | `images` | string[] or null | No | Ordered array of valid image URLs. First is the hero image. |
 | `features` | string[] or null | No | Feature tags from the listing (e.g. `["garage", "pool", "elevator"]`). Encouraged — a Tier 3 warning is issued if missing. |

--- a/docs/validation-rules.md
+++ b/docs/validation-rules.md
@@ -34,6 +34,7 @@ Does the listing conform to the data model? These check structural correctness.
 | `valid_enum` | `listing_type`, `rent_period`, `listing_status`, `property_type`, `location_granularity` | Must be one of the allowed values (skips null/undefined) | `{"field": "listing_type", "rule": "valid_enum", "value": "lease", "expected": "One of: sale, rent"}` |
 | `valid_type` | All fields | Must match the declared type (string, number, integer, object, array) | `{"field": "bedrooms", "rule": "valid_type", "value": "three", "expected": "integer"}` |
 | `valid_url` | `source_url`, each item in `images` | Must be a parseable URL | `{"field": "images[2]", "rule": "valid_url", "value": "not-a-url"}` |
+| `nonempty_title` | `title` | After trimming leading/trailing whitespace, must be ≥ 1 character. Also enforced at the DB level by the `listings_title_nonempty` CHECK constraint. | `{"field": "title", "rule": "nonempty_title", "value": "   "}` |
 | `rent_period_required` | `rent_period` | Must be non-null when `listing_type` is `rent` | `{"field": "rent_period", "rule": "rent_period_required", "value": null}` |
 
 ### Expected field types

--- a/src/lib/notices.ts
+++ b/src/lib/notices.ts
@@ -53,10 +53,10 @@ const ALL_NOTICES: Notice[] = [
     expires: '2026-04-14',
   },
   {
-    id: 'title-required',
+    id: 'title-nonempty',
     message:
-      'The "title" field is now required. Listings submitted without a non-empty title (string, max 500 chars) will be rejected at Tier 1 validation. Update your scraper to extract and include the listing title.',
-    expires: '2026-04-10',
+      'The "title" field is now trimmed before validation, and titles that are empty or whitespace-only are rejected at Tier 1. A matching DB CHECK constraint blocks the same case at the storage layer. Ensure your scraper sends a real, non-empty title.',
+    expires: '2026-05-11',
   },
   {
     id: 'scraper-config-update',

--- a/src/types/listing.ts
+++ b/src/types/listing.ts
@@ -45,7 +45,7 @@ export const ListingInputSchema = z.object({
   property_type: z.enum(PROPERTY_TYPES),
   property_subtype: z.string().max(100).nullable().optional(),
   raw_property_type: z.string().max(500).nullable().optional(),
-  title: z.string().min(1).max(500),
+  title: z.string().trim().min(1).max(500),
   description: z.string().nullable().optional(),
   images: z.array(z.string().url()).nullable().optional(),
   features: z.array(z.string()).nullable().optional(),

--- a/src/validation/rules/nonempty-title.ts
+++ b/src/validation/rules/nonempty-title.ts
@@ -1,0 +1,18 @@
+import type { ValidationRule, ValidationIssue } from '../../types/validation.js';
+
+/**
+ * Reject titles that are empty or whitespace-only.
+ * `requiredFields` only catches null/undefined; this catches `""` and `"   "`.
+ * Mirrors the DB-level `listings_title_nonempty` CHECK constraint.
+ */
+export const nonemptyTitle: ValidationRule = {
+  name: 'nonempty_title',
+  check(input) {
+    const issues: ValidationIssue[] = [];
+    const value = input.title;
+    if (typeof value === 'string' && value.trim().length === 0) {
+      issues.push({ field: 'title', rule: 'nonempty_title', value });
+    }
+    return issues;
+  },
+};

--- a/src/validation/tier1-schema.ts
+++ b/src/validation/tier1-schema.ts
@@ -6,6 +6,7 @@ import { validEnums } from './rules/valid-enums.js';
 import { validTypes } from './rules/valid-types.js';
 import { validUrl } from './rules/valid-url.js';
 import { rentPeriodRequired } from './rules/rent-period-required.js';
+import { nonemptyTitle } from './rules/nonempty-title.js';
 
 export const tier1Rules: ValidationRule[] = [
   requiredFields,
@@ -15,4 +16,5 @@ export const tier1Rules: ValidationRule[] = [
   validTypes,
   validUrl,
   rentPeriodRequired,
+  nonemptyTitle,
 ];

--- a/supabase/migrations/00024_backfill_empty_titles.sql
+++ b/supabase/migrations/00024_backfill_empty_titles.sql
@@ -1,0 +1,21 @@
+-- Backfill empty titles left by 00018_add_title_column.sql.
+-- Format: "<typology> in <area>"
+--   typology: T-notation (T0/T1/T2/...) extracted from raw_property_type, else
+--             T0 if bedrooms = 0, else a property_type-derived label.
+--   area:     most-specific available admin region (admin_level_3 → 2 → 1).
+UPDATE listings
+SET title = (
+  CASE
+    WHEN raw_property_type ~* '\mT\d+\M'
+      THEN upper((regexp_match(raw_property_type, 'T\d+', 'i'))[1])
+    WHEN bedrooms = 0
+      THEN 'T0'
+    WHEN property_type = 'apartment' THEN 'Apartment'
+    WHEN property_type = 'parking'   THEN 'Parking'
+    WHEN property_type = 'mixed_use' THEN 'Building'
+    ELSE 'Property'
+  END
+  || ' in '
+  || coalesce(admin_level_3, admin_level_2, admin_level_1, 'Unknown')
+)
+WHERE title = '';

--- a/supabase/migrations/00025_enforce_nonempty_title.sql
+++ b/supabase/migrations/00025_enforce_nonempty_title.sql
@@ -1,0 +1,5 @@
+-- Enforce non-empty title at the DB level. Mirrors the API-layer Zod rule
+-- (z.string().trim().min(1)) so that direct DB writes can't bypass it.
+-- Migration 00024 must run first to clear any pre-existing empty rows.
+ALTER TABLE listings
+  ADD CONSTRAINT listings_title_nonempty CHECK (btrim(title) <> '');

--- a/tests/unit/validation/nonempty-title.test.ts
+++ b/tests/unit/validation/nonempty-title.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from 'vitest';
+import { nonemptyTitle } from '../../../src/validation/rules/nonempty-title.js';
+import { makeValidListing, makeValidContext } from '../../fixtures/valid-listing.js';
+
+describe('nonempty_title', () => {
+  const ctx = makeValidContext();
+
+  it('passes for a normal title', () => {
+    const listing = makeValidListing({ title: 'T2 in Belém' });
+    expect(nonemptyTitle.check(listing, ctx)).toEqual([]);
+  });
+
+  it('rejects an empty string', () => {
+    const listing = makeValidListing({ title: '' });
+    const issues = nonemptyTitle.check(listing, ctx);
+    expect(issues).toHaveLength(1);
+    expect(issues[0]).toMatchObject({ field: 'title', rule: 'nonempty_title', value: '' });
+  });
+
+  it('rejects whitespace-only', () => {
+    const listing = makeValidListing({ title: '   ' });
+    const issues = nonemptyTitle.check(listing, ctx);
+    expect(issues).toHaveLength(1);
+    expect(issues[0].rule).toBe('nonempty_title');
+  });
+
+  it('skips when title is missing (handled by required_field)', () => {
+    const listing = makeValidListing({ title: null as unknown as string });
+    expect(nonemptyTitle.check(listing, ctx)).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a Tier 1 `nonempty_title` rule. The existing `z.string().min(1)` on `ListingInputSchema` was never wired into the validation pipeline (schema is type-only) — empty/whitespace titles weren't actually being rejected at the API.
- Adds DB CHECK constraint `listings_title_nonempty CHECK (btrim(title) <> '')` so direct writes can't bypass it.
- Backfills the 218 pre-existing empty-title rows left by migration 00018 with a derived `"<typology> in <area>"` title (e.g. `"T1 in Belém"`) sourced from `raw_property_type` and `admin_level_3`.

## Migrations
Already applied to prod via `supabase db push` ahead of this PR (backfill must run before the CHECK or the constraint creation fails). Verification: `empty_count = 0`, `whitespace_only_count = 0`.

## Test plan
- [x] `npm test` — 67/67 pass (4 new tests for `nonempty_title`)
- [x] `npx tsc --noEmit` — clean
- [x] DB verification queries post-backfill
- [ ] Post-merge: deploy via `npx vercel deploy --prod` and smoke-test rejection of `title: "   "`

🤖 Generated with [Claude Code](https://claude.com/claude-code)